### PR TITLE
Replace babelizer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
 - conda install python=$TRAVIS_PYTHON_VERSION
 - conda install -q conda-build anaconda-client coverage sphinx
 script:
-- conda build ./recipe -c csdms-stack -c conda-forge --old-build-string
+- conda build ./recipe -c csdms-stack -c defaults -c conda-forge --old-build-string
 after_success:
 - curl https://raw.githubusercontent.com/csdms/ci-tools/master/anaconda_upload.py > $HOME/anaconda_upload.py
 - echo $ANACONDA_TOKEN | python $HOME/anaconda_upload.py ./recipe --channel=main --org=csdms-stack --old-build-string --token=-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,6 @@ requirements:
   build:
     - babelizer
     - hydrotrend
-    - gcc [osx]
   run:
     - cca-babel <2
     - cca-spec-babel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,9 @@ requirements:
     - hydrotrend
     - scipy <=0.18.1
   run:
-    - babelizer
+    - cca-babel <2
+    - cca-spec-babel
+    - ccaffeine
     - hydrotrend
     - scipy <=0.18.1
 
@@ -25,7 +27,7 @@ test:
     - pymt
 
 build:
-  number: 3
+  number: 4
 
 about:
   home: http://csdms.colorado.edu/wiki/Model:HydroTrend

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ requirements:
   build:
     - babelizer
     - hydrotrend
+    - gcc [osx]
   run:
     - cca-babel <2
     - cca-spec-babel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,21 +13,17 @@ requirements:
   build:
     - babelizer
     - hydrotrend
-    - scipy <=0.18.1
   run:
     - cca-babel <2
     - cca-spec-babel
-    - ccaffeine
     - hydrotrend
-    - scipy <=0.18.1
 
 test:
   requires:
-    - matplotlib
     - pymt
 
 build:
-  number: 4
+  number: 5
 
 about:
   home: http://csdms.colorado.edu/wiki/Model:HydroTrend

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -11,3 +11,8 @@ model = Model()
 for default in model.defaults:
     print('{name}: {val} {units}'.format(
         name=default[0], val=default[1][0], units=default[1][1]))
+
+config_file, initdir = model.setup(os.getcwd())
+model.initialize(config_file, dir=initdir)
+model.update()
+model.finalize()


### PR DESCRIPTION
The babelizer depends on `conda-build`, which can't be installed into a conda environment. In this PR, we've replaced the `babelizer` run dependency with what's really needed: `cca-babel` and `cca-spec-babel`. Also, because of improvement upstream, we were able to remove the `scipy` and `matplotlib` dependencies.